### PR TITLE
Fix the build

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,12 +1,13 @@
 'use strict';
 
-Object.defineProperty(exports, '__esModule', {
+Object.defineProperty(exports, "__esModule", {
     value: true
 });
 
 var _acorn = require('acorn');
 
-exports['default'] = getDependencies;
+exports.default = getDependencies;
+
 
 var defaultOpts = {
     ecmaVersion: 5,
@@ -14,7 +15,7 @@ var defaultOpts = {
 };
 
 function getDependencies(contents) {
-    var opts = arguments.length <= 1 || arguments[1] === undefined ? defaultOpts : arguments[1];
+    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : defaultOpts;
 
     var ast = (0, _acorn.parse)(contents, { sourceType: 'module', ecmaVersion: opts.ecmaVersion });
 

--- a/package.json
+++ b/package.json
@@ -8,14 +8,16 @@
     "acorn": "^2.4.0"
   },
   "devDependencies": {
-    "babel": "^5.8.23",
+    "babel-cli": "^6.26.0",
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-preset-env": "^1.6.1",
     "istanbul": "^0.3.20",
     "mocha": "^2.3.2",
     "should": "^7.1.0"
   },
   "scripts": {
     "test": "_mocha",
-    "build": "babel modules/index.js > dist/index.js",
+    "build": "babel --presets=env --plugins=add-module-exports modules/index.js > dist/index.js",
     "test-cover": "./node_modules/istanbul/lib/cli.js cover _mocha"
   },
   "author": "",


### PR DESCRIPTION
I couldn't get the build to work when I cloned master.

I tried

```sh
npm i
npm run build
```

but babel threw `TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string`

I couldn't figure that out, so I just upgraded babel.